### PR TITLE
feat: Add a one-time home page to the application

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,37 +1,47 @@
 # app.py
 import streamlit as st
+from src.util import show_home_page
 
-st.set_page_config(layout="wide")
+# Initialize session state for home page
+if 'home_page_complete' not in st.session_state:
+    st.session_state.home_page_complete = False
 
-pages = {
-    "Data": [st.Page("preprocessing.py", title="Prepare / Clean", icon=":material/build:")]
-}
+# Show home page if not complete
+if not st.session_state.home_page_complete:
+    # NOTE: The user can change this URL to a local path or another URL.
+    show_home_page(background_image_path="https://img.freepik.com/free-vector/background-gradient-line-digital-abstract_483537-2954.jpg")
+else:
+    st.set_page_config(layout="wide")
 
-ptype = st.session_state.get("problem_type")  # set in preprocessing.py
-# Show models only after the user confirmed target/problem type
-if st.session_state.get("confirmed") and ptype:
-    
-    if ptype in ["classification_binary", "classification_multi"]:
-        pages["Models"] = [
-            st.Page("models/KNN.py",            title="KNN (Classifier)",  icon=":material/science:"),
-            st.Page("models/Random Forest.py",  title="Random Forest (Clf)", icon=":material/forest:"),
-            st.Page("models/SVM.py",            title="SVM (SVC)",         icon=":material/bolt:"),
-            st.Page("models/Logistic Regression.py", title="Logistic Regression", icon=":material/linear_scale:"),
-            st.Page("models/Naive Bayes.py",    title="Naive Bayes",       icon=":material/inbox:"),
-            st.Page("models/XGBoost.py",        title="XGBoost",           icon=":material/rocket_launch:"),
-        ]
+    pages = {
+        "Data": [st.Page("preprocessing.py", title="Prepare / Clean", icon=":material/build:")]
+    }
+
+    ptype = st.session_state.get("problem_type")  # set in preprocessing.py
+    # Show models only after the user confirmed target/problem type
+    if st.session_state.get("confirmed") and ptype:
+
+        if ptype in ["classification_binary", "classification_multi"]:
+            pages["Models"] = [
+                st.Page("models/KNN.py",            title="KNN (Classifier)",  icon=":material/science:"),
+                st.Page("models/Random Forest.py",  title="Random Forest (Clf)", icon=":material/forest:"),
+                st.Page("models/SVM.py",            title="SVM (SVC)",         icon=":material/bolt:"),
+                st.Page("models/Logistic Regression.py", title="Logistic Regression", icon=":material/linear_scale:"),
+                st.Page("models/Naive Bayes.py",    title="Naive Bayes",       icon=":material/inbox:"),
+                st.Page("models/XGBoost.py",        title="XGBoost",           icon=":material/rocket_launch:"),
+            ]
+
+        elif ptype == "regression":
+            pages["Models"] = [
+                st.Page("models/KNN.py",            title="KNN (Regressor)",   icon=":material/science:"),
+                st.Page("models/Random Forest.py",  title="Random Forest (Reg)", icon=":material/forest:"),
+                st.Page("models/SVM.py",            title="SVM (SVR)",         icon=":material/bolt:"),
+                st.Page("models/Linear Models.py",  title="Linear Models",     icon=":material/straighten:"),
+                st.Page("models/XGBoost.py",        title="XGBoost",           icon=":material/rocket_launch:"),
+            ]
         
-    elif ptype == "regression":
-        pages["Models"] = [
-            st.Page("models/KNN.py",            title="KNN (Regressor)",   icon=":material/science:"),
-            st.Page("models/Random Forest.py",  title="Random Forest (Reg)", icon=":material/forest:"),
-            st.Page("models/SVM.py",            title="SVM (SVR)",         icon=":material/bolt:"),
-            st.Page("models/Linear Models.py",  title="Linear Models",     icon=":material/straighten:"),
-            st.Page("models/XGBoost.py",        title="XGBoost",           icon=":material/rocket_launch:"),
-        ]
-    
-    elif ptype == "forecasting":
-        print("ouch, gotta work on that")
+        elif ptype == "forecasting":
+            print("ouch, gotta work on that")
 
-pg = st.navigation(pages, position="sidebar", expanded=True)
-pg.run()
+    pg = st.navigation(pages, position="sidebar", expanded=True)
+    pg.run()

--- a/src/util.py
+++ b/src/util.py
@@ -249,3 +249,44 @@ def generate_model_formula_latex(y: pd.Series, X: pd.DataFrame, model_type: str,
         formula = r'Invalid Model Type'
     
     return formula
+
+
+
+def show_home_page(background_image_path):
+    """
+    Displays the home page with a background image, title, description, and a button to proceed.
+
+    Args:
+        background_image_path (str): The path to the background image.
+    """
+    # NOTE: The user should provide the actual path to the background image.
+    # For now, we'll use a placeholder.
+    # Example: set_background('assets/background.png')
+
+    st.markdown(
+        f"""
+         <style>
+         .stApp {{
+             background-image: url("{background_image_path}");
+             background-attachment: fixed;
+             background-size: cover
+         }}
+         .bottom-right-button {{
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+         }}
+         </style>
+         """,
+        unsafe_allow_html=True
+    )
+
+    st.title("Dataset analysis playground")
+    st.write("This application helps you analyze your dataset. You can clean your data, visualize it, and train machine learning models.")
+
+    # "Let's go" button in the bottom right
+    st.markdown('<div class="bottom-right-button">', unsafe_allow_html=True)
+    if st.button("Let's go!"):
+        st.session_state.home_page_complete = True
+        st.rerun()
+    st.markdown('</div>', unsafe_allow_html=True)


### PR DESCRIPTION
This commit introduces a home page that is displayed only once at the start of the application session. The home page includes a background image, a title, and a short description of the application.

A "Let's go" button allows the user to navigate to the main application. The home page is implemented using a new function `show_home_page` in `src/util.py` and is controlled by a session state variable `home_page_complete` in `app.py`.